### PR TITLE
Separate agent purchase route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ const authRoutes = require('./routes/auth');
 const subscriptionRoutes = require('./routes/subscriptions');
 const llmRoutes = require('./routes/llm');
 const agentRoutes = require('./routes/agents');
+const agentPurchaseRoutes = require('./routes/agentPurchases');
 
 //验证是否调用了.env信息
 console.log('> DB HOST:', process.env.DB_HOST);
@@ -18,6 +19,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/llm', llmRoutes);
 app.use('/api/agents', agentRoutes);
+app.use('/api/agents', agentPurchaseRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/server/routes/agentPurchases.js
+++ b/server/routes/agentPurchases.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const auth = require('../middlewares/jwtauth');
+const { purchaseAgent } = require('../services/agentService');
+
+const router = express.Router();
+
+// purchase single agent
+router.post('/purchase', auth, async (req, res) => {
+  const { agentId, duration } = req.body;
+  if (!agentId || !duration) {
+    return res.status(400).json({ message: 'agentId and duration required' });
+  }
+  try {
+    await purchaseAgent({ userId: req.user.id, agentId, duration });
+    res.json({ message: 'Agent purchased' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/server/routes/agents.js
+++ b/server/routes/agents.js
@@ -18,31 +18,6 @@ router.get('/', async (req, res) => {
   }
 });
 
-// purchase single agent
-router.post('/purchase', auth, async (req, res) => {
-  const { agentId, duration } = req.body;
-  if (!agentId || !duration) {
-    return res.status(400).json({ message: 'agentId and duration required' });
-  }
-  try {
-    const [agents] = await pool.query(
-      'SELECT id FROM wensoul_agent WHERE id = ? AND status = 1',
-      [agentId]
-    );
-    if (agents.length === 0) {
-      return res.status(404).json({ message: 'Agent not found' });
-    }
-    const userId = req.user.id;
-    await pool.query(
-      'INSERT INTO wensoul_user_agent (user_id, agent_id, subscription_duration, subscription_expire_time) VALUES (?, ?, ?, DATE_ADD(NOW(), INTERVAL ? DAY))',
-      [userId, agentId, duration, duration]
-    );
-    res.json({ message: 'Agent purchased' });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'Server error' });
-  }
-});
 
 // run agent workflow
 router.post('/:id/run', auth, async (req, res) => {

--- a/server/services/agentService.js
+++ b/server/services/agentService.js
@@ -23,6 +23,22 @@ async function userHasAgent(userId, agentId) {
   return rows.length > 0;
 }
 
+async function purchaseAgent({ userId, agentId, duration }) {
+  const [agents] = await pool.query(
+    'SELECT id FROM wensoul_agent WHERE id = ? AND status = 1',
+    [agentId]
+  );
+  if (agents.length === 0) {
+    throw new Error('Agent not found');
+  }
+
+  await pool.query(
+    `INSERT INTO wensoul_user_agent (user_id, agent_id, subscription_duration, subscription_expire_time)
+     VALUES (?, ?, ?, DATE_ADD(NOW(), INTERVAL ? DAY))`,
+    [userId, agentId, duration, duration]
+  );
+}
+
 async function runAgent(agentId, input) {
   const [rows] = await pool.query(
     'SELECT workflow FROM wensoul_agent WHERE id = ? AND status = 1',
@@ -53,6 +69,7 @@ async function runAgent(agentId, input) {
 module.exports = {
   runAgent,
   userHasActiveSubscription,
-  userHasAgent
+  userHasAgent,
+  purchaseAgent
 };
 


### PR DESCRIPTION
## Summary
- refactor agent purchasing into its own router
- implement `purchaseAgent` service helper
- register new agent purchase router in the server

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*
- `npm --prefix server start` *(fails: cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6848d9cd9414832899c27d8f2dd648a6