### PR TITLE
Add payload support to llm service

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ npm start
 ```
 The server listens on port 3000 by default.
 
+The `.env` file also contains API endpoint variables used for different
+modalities. See the comments in `server/.env.example` for details.
+
 ### Endpoints
 - `POST /api/register` – register a new user using JSON `{username, password, email?, phone?}`
 - `POST /api/login` – obtain a JWT token with `{username, password}`
@@ -66,3 +69,16 @@ The server listens on port 3000 by default.
 - `GET /api/agents` – list available agents
 - `POST /api/agents/purchase` – purchase a single agent (requires auth)
 - `POST /api/agents/:id/run` – run an agent's workflow (requires active plan or purchase)
+
+### Agent Workflows
+Workflows are defined as ordered arrays of nodes stored in the database. Each
+node specifies a `nodeType` that determines which LLM endpoint is called.
+
+Supported `nodeType` values and the payloads sent to the LLM service:
+
+- **text-to-text** – `{ model, messages: [{ role: 'user', content: prompt }] }`
+- **text-to-image** – `{ prompt, model, n, size }`
+- **image-to-image** – `{ prompt, model, image }`
+- **image-to-model** – `{ image, model }`
+
+The service automatically selects the correct API URL based on `nodeType`.

--- a/server/.env.example
+++ b/server/.env.example
@@ -33,17 +33,17 @@ LLM_API_KEY=your_llm_platform_api_key
 LLM_MODEL=gpt-4-turbo
 
 # --- LLM API Endpoints ---
-# Specific API URLs for different model modalities.
-# These are selected by agentService.js based on the `nodeType` in the workflow.
+# API URLs for different modalities. The agent workflow selects one based on
+# each node's `nodeType` value.
 
-# 文生文
+# Text-to-Text (chat completions)
 T2T_API_URL=https://api.yourplatform.com/v1/chat/completions
 
-# 文生图
+# Text-to-Image (image generation)
 T2I_API_URL=https://api.yourplatform.com/v1/images/generations
 
-# 图生图
-I2I_API_URL=https://api.yourplatform.com/v1/images/generations
+# Image-to-Image (edit/variation generation)
+I2I_API_URL=https://api.yourplatform.com/v1/images/edits
 
-# 图生模型
+# Image-to-Model (custom model training)
 I2M_API_URL=https://api.yourplatform.com/v1/models/generations

--- a/server/services/llmService.js
+++ b/server/services/llmService.js
@@ -6,7 +6,7 @@ const axios = require('axios');
  * LLM_API_KEY   - key for authenticating with the provider
  * LLM_API_URL   - HTTP endpoint for chat completions
  */
-async function callLLM({ prompt, model, apiUrl, apiKey }) {
+async function callLLM({ payload, prompt, model, apiUrl, apiKey }) {
   const finalApiKey = apiKey || process.env.LLM_API_KEY;
   const finalUrl = apiUrl || process.env.LLM_API_URL ||
     'https://api.openai.com/v1/chat/completions';
@@ -15,7 +15,9 @@ async function callLLM({ prompt, model, apiUrl, apiKey }) {
     throw new Error('LLM API key not configured');
   }
 
-  const body = {
+  // If a full payload is provided use it directly, otherwise build the
+  // default chat-completion body from the prompt and model.
+  const body = payload || {
     model: model || process.env.LLM_MODEL || 'gpt-3.5-turbo',
     messages: [{ role: 'user', content: prompt }]
   };


### PR DESCRIPTION
## Summary
- allow passing a custom payload into `callLLM`
- build payloads for each `nodeType` in `agentService`
- document API endpoint vars in `.env.example`
- explain workflow node types and payloads in README

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a71dfbc708328b6e6cb05a2e63f28