### PR TITLE
更新数据库文档并新增后端说明

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -210,10 +210,10 @@ database/
 ├── wensoul_user_assets.sql            # 用户资产管理相关表
 ├── wensoul_user_usage_stats.sql       # 使用统计和配额表
 ├── wensoul_user.sql                   # 用户表（已更新）
-├── wensoul_agent.sql                  # 代理表
-├── wensoul_user_agent.sql             # 用户代理关联表
+├── wensoul_agent.sql                  # 智能体表
+├── wensoul_user_agent.sql             # 用户智能体表
 ├── wensoul_agent_runs.sql             # 智能体运行记录表
 ├── init_all_tables.sql                # 完整初始化脚本
 ├── init_complete.sql                  # 单文件初始化脚本
 └── README.md                          # 详细设计文档
-``` 
+```

--- a/database/README.md
+++ b/database/README.md
@@ -9,6 +9,11 @@
 3. **安全性**：完善的外键约束和数据完整性保护
 4. **监控友好**：完善的统计表，便于系统监控和分析
 
+数据库脚本全部位于 `database` 目录下，按功能拆分为多个 SQL 文件。同时提供
+`init_all_tables.sql` 以及 `init_complete.sql` 两套初始化脚本：前者通过
+`SOURCE` 指令依次加载各表定义，适合按需定制；后者将所有表结构整合为单一
+文件，便于一次性执行。
+
 ## 表结构说明
 
 ### 1. 订阅套餐表 (`wensoul_subscription_plans`)
@@ -104,6 +109,17 @@
 - 性能指标追踪
 - 便于容量规划
 
+### 7. 智能体相关表
+
+#### 7.1 智能体表 (`wensoul_agent`)
+- 平台内置的智能体配置及其工作流定义
+
+#### 7.2 用户智能体表 (`wensoul_user_agent`)
+- 记录用户单独购买的智能体以及订阅时长
+
+#### 7.3 智能体运行记录表 (`wensoul_agent_runs`)
+- 按运行实例追踪每个工作流的状态与节点结果
+
 ## 索引设计
 
 ### 主要索引策略：
@@ -171,7 +187,7 @@ ALTER TABLE wensoul_user_usage_daily PARTITION BY RANGE (TO_DAYS(date)) (
 
 ## 使用建议
 
-1. **初始化**：执行 `init_all_tables.sql` 进行完整初始化
+1. **初始化**：可选择执行 `init_all_tables.sql` 或 `init_complete.sql` 完成数据库初始化
 2. **监控**：定期检查 `wensoul_system_usage_stats` 表的系统负载
 3. **清理**：定期清理软删除的数据和历史统计数据
 4. **备份**：重点关注用户数据和订阅信息的备份
@@ -191,11 +207,13 @@ database/
 ├── wensoul_subscription_plans.sql      # 订阅套餐表
 ├── wensoul_user_subscriptions.sql     # 用户订阅记录表
 ├── wensoul_user_storage.sql           # 云存储相关表
-├── wensoul_user_assets.sql            # 用户资产管理相关表  
+├── wensoul_user_assets.sql            # 用户资产管理相关表
 ├── wensoul_user_usage_stats.sql       # 使用统计和配额表
 ├── wensoul_user.sql                   # 用户表（已更新）
 ├── wensoul_agent.sql                  # 代理表
 ├── wensoul_user_agent.sql             # 用户代理关联表
+├── wensoul_agent_runs.sql             # 智能体运行记录表
 ├── init_all_tables.sql                # 完整初始化脚本
+├── init_complete.sql                  # 单文件初始化脚本
 └── README.md                          # 详细设计文档
 ``` 

--- a/server/README.md
+++ b/server/README.md
@@ -1,47 +1,47 @@
-# 后端服務說明
+# 后端服务说明
 
-本目錄為文枢鏈的後端代碼，基於 Node.js 與 Express 框架實現。服務通過 MySQL 數據庫存儲用戶、訂閱及智能體等資料，並提供一組 REST API 供前端調用。
+本目录为文枢链的后端代码，基于 Node.js 与 Express 框架实现。服务通过 MySQL 数据库存储用户、订阅及智能体等数据，并提供一组 REST API 供前端调用。
 
 ## 主要特性
-- 使用 `express` 構建 API 服務
-- 在 `config/db.js` 中配置 MySQL 連接池
-- `middlewares/jwtauth.js` 實現 JWT 驗證
-- 路由按功能劃分：auth、subscriptions、agents、agentPurchases、llm 等
-- 服務層封裝在 `services/` 內，包含智能體工作流與大模型調用邏輯
-- 支持從 `.env` 文件讀取環境變量，可參考 `.env.example`
+- 使用 `express` 构建 API 服务
+- 在 `config/db.js` 中配置 MySQL 连接池
+- `middlewares/jwtauth.js` 实现 JWT 验证
+- 路由按功能划分：auth、subscriptions、agents、agentPurchases、llm 等
+- 服务层封装在 `services/` 内，包含智能体工作流与大模型调用逻辑
+- 支持从 `.env` 文件读取环境变量，可参考 `.env.example`
 
-## 目錄結構
+## 目录结构
 ```
 server/
-├── config/                # 數據庫連接配置
+├── config/                # 数据库连接配置
 │   └── db.js
-├── middlewares/           # 中間件
+├── middlewares/           # 中间件
 │   └── jwtauth.js
-├── routes/                # 路由定義
+├── routes/                # 路由定义
 │   ├── auth.js
 │   ├── subscriptions.js
 │   ├── agents.js
 │   ├── agentPurchases.js
 │   └── llm.js
-├── services/              # 業務邏輯
+├── services/              # 业务逻辑
 │   ├── agentService.js
 │   ├── purchaseService.js
 │   ├── llmService.js
 │   └── subsrciptionService.js
-├── index.js               # 應用入口
+├── index.js               # 应用入口
 ├── package.json
-└── .env.example           # 環境變量模板
+└── .env.example           # 环境变量模板
 ```
 
-## 快速開始
-1. 進入此目錄執行 `npm install` 安裝依賴。
-2. 將 `.env.example` 複製為 `.env`，填寫資料庫及 API 配置。
-3. 執行 `npm start` 啟動服務，默認監聽 3000 端口。
+## 快速开始
+1. 进入此目录执行 `npm install` 安装依赖。
+2. 将 `.env.example` 复制为 `.env`，填写数据库及 API 配置。
+3. 执行 `npm start` 启动服务，默认监听 3000 端口。
 
 ## 常用接口
-- `POST /api/auth/register` 用戶註冊
-- `POST /api/auth/login` 用戶登入並獲取 JWT
-- `GET /api/subscriptions/plans` 取得訂閱套餐
-- `POST /api/subscriptions/subscribe` 訂閱指定套餐
-- `GET /api/agents` 查詢可用智能體
-- `POST /api/agents/:id/run` 運行智能體工作流
+- `POST /api/auth/register` 用户注册
+- `POST /api/auth/login` 用户登录并获取 JWT
+- `GET /api/subscriptions/plans` 获取订阅套餐
+- `POST /api/subscriptions/subscribe` 订阅指定套餐
+- `GET /api/agents` 查询可用智能体
+- `POST /api/agents/:id/run` 运行智能体工作流

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,47 @@
+# 后端服務說明
+
+本目錄為文枢鏈的後端代碼，基於 Node.js 與 Express 框架實現。服務通過 MySQL 數據庫存儲用戶、訂閱及智能體等資料，並提供一組 REST API 供前端調用。
+
+## 主要特性
+- 使用 `express` 構建 API 服務
+- 在 `config/db.js` 中配置 MySQL 連接池
+- `middlewares/jwtauth.js` 實現 JWT 驗證
+- 路由按功能劃分：auth、subscriptions、agents、agentPurchases、llm 等
+- 服務層封裝在 `services/` 內，包含智能體工作流與大模型調用邏輯
+- 支持從 `.env` 文件讀取環境變量，可參考 `.env.example`
+
+## 目錄結構
+```
+server/
+├── config/                # 數據庫連接配置
+│   └── db.js
+├── middlewares/           # 中間件
+│   └── jwtauth.js
+├── routes/                # 路由定義
+│   ├── auth.js
+│   ├── subscriptions.js
+│   ├── agents.js
+│   ├── agentPurchases.js
+│   └── llm.js
+├── services/              # 業務邏輯
+│   ├── agentService.js
+│   ├── purchaseService.js
+│   ├── llmService.js
+│   └── subsrciptionService.js
+├── index.js               # 應用入口
+├── package.json
+└── .env.example           # 環境變量模板
+```
+
+## 快速開始
+1. 進入此目錄執行 `npm install` 安裝依賴。
+2. 將 `.env.example` 複製為 `.env`，填寫資料庫及 API 配置。
+3. 執行 `npm start` 啟動服務，默認監聽 3000 端口。
+
+## 常用接口
+- `POST /api/auth/register` 用戶註冊
+- `POST /api/auth/login` 用戶登入並獲取 JWT
+- `GET /api/subscriptions/plans` 取得訂閱套餐
+- `POST /api/subscriptions/subscribe` 訂閱指定套餐
+- `GET /api/agents` 查詢可用智能體
+- `POST /api/agents/:id/run` 運行智能體工作流


### PR DESCRIPTION
## Summary
- 更新 `database/README.md`：补充初始化脚本说明、新增智能体相关表介绍，并完善文件列表
- 在 `server` 目录新增中文 `README.md`

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a74deda208328ad1907e7b46f3544