### PR TITLE
Add Babel plugin for private methods

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset'
-  ]
+  presets: ['@vue/cli-plugin-babel/preset'],
+  plugins: ['@babel/plugin-transform-private-methods']
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@babel/core": "^7.12.16",
         "@babel/eslint-parser": "^7.27.5",
+        "@babel/plugin-transform-private-methods": "^7.27.1",
         "@vue/cli-plugin-babel": "~5.0.0",
         "@vue/cli-plugin-eslint": "~5.0.0",
         "@vue/cli-service": "~5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.16",
     "@babel/eslint-parser": "^7.27.5",
+    "@babel/plugin-transform-private-methods": "^7.27.1",
     "@vue/cli-plugin-babel": "~5.0.0",
     "@vue/cli-plugin-eslint": "~5.0.0",
     "@vue/cli-service": "~5.0.0",


### PR DESCRIPTION
## Summary
- add `@babel/plugin-transform-private-methods` dev dependency
- enable plugin in `babel.config.js`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685513a3d504832892443e7882322a14