### PR TITLE
Add workflow routes with auth

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,6 +6,7 @@ const subscriptionRoutes = require('./routes/subscriptions');
 const llmRoutes = require('./routes/llm');
 const agentRoutes = require('./routes/agents');
 const agentPurchaseRoutes = require('./routes/agentPurchases');
+const workflowRoutes = require('./routes/workflows');
 
 
 //验证是否调用了.env信息
@@ -21,6 +22,7 @@ app.use('/api/subscriptions', subscriptionRoutes);
 app.use('/api/llm', llmRoutes);
 app.use('/api/agents', agentRoutes);
 app.use('/api/agents', agentPurchaseRoutes);
+app.use('/api/workflows', workflowRoutes);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {

--- a/server/routes/workflows.js
+++ b/server/routes/workflows.js
@@ -1,0 +1,50 @@
+const express = require('express');
+const auth = require('../middlewares/jwtauth');
+const workflowService = require('../services/workflowService');
+const path = require('path');
+
+const router = express.Router();
+
+// GET /api/workflows/:runId
+router.get('/:runId', auth, async (req, res) => {
+  const runId = req.params.runId;
+  const userId = req.user.id;
+  try {
+    const run = await workflowService.getRunById(runId, userId);
+    if (!run) {
+      return res.status(404).json({ message: 'Run not found' });
+    }
+    res.json(run);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// POST /api/workflows/:runId/nodes/:nodeId/save
+router.post('/:runId/nodes/:nodeId/save', auth, async (req, res) => {
+  const { runId, nodeId } = req.params;
+  const userId = req.user.id;
+  try {
+    const result = await workflowService.saveNodeOutput(runId, nodeId, userId);
+    res.json({ message: 'saved', ...result });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: err.message });
+  }
+});
+
+// GET /api/workflows/:runId/nodes/:nodeId/download
+router.get('/:runId/nodes/:nodeId/download', auth, async (req, res) => {
+  const { runId, nodeId } = req.params;
+  const userId = req.user.id;
+  try {
+    const { filePath, fileName } = await workflowService.getNodeOutputFile(runId, nodeId, userId);
+    res.download(filePath, fileName);
+  } catch (err) {
+    console.error(err);
+    res.status(404).json({ message: err.message });
+  }
+});
+
+module.exports = router;

--- a/server/services/workflowService.js
+++ b/server/services/workflowService.js
@@ -1,0 +1,72 @@
+const fs = require('fs').promises;
+const path = require('path');
+const pool = require('../config/db');
+
+const STORAGE_DIR = path.join(__dirname, '..', 'storage');
+
+async function getRunById(runId, userId) {
+  const [rows] = await pool.query(
+    `SELECT run_id, user_id, agent_id, status, current_node_id, node_results, create_time, update_time
+     FROM wensoul_agent_runs WHERE run_id = ? AND user_id = ?`,
+    [runId, userId]
+  );
+  return rows[0];
+}
+
+async function saveNodeOutput(runId, nodeId, userId) {
+  const run = await getRunById(runId, userId);
+  if (!run) {
+    throw new Error('Run not found');
+  }
+  if (!run.node_results) {
+    throw new Error('No node results recorded');
+  }
+  let results;
+  try {
+    results = typeof run.node_results === 'string' ? JSON.parse(run.node_results) : run.node_results;
+  } catch (err) {
+    throw new Error('Invalid node results format');
+  }
+  const nodeData = results[nodeId];
+  if (!nodeData || !nodeData.output) {
+    throw new Error('Node output not found');
+  }
+  const output = typeof nodeData.output === 'string' ? nodeData.output : JSON.stringify(nodeData.output);
+  await fs.mkdir(STORAGE_DIR, { recursive: true });
+  const fileName = `run_${runId}_node_${nodeId}_${Date.now()}.txt`;
+  const filePath = path.join(STORAGE_DIR, fileName);
+  await fs.writeFile(filePath, output, 'utf8');
+  const fileSize = Buffer.byteLength(output, 'utf8');
+  const [result] = await pool.query(
+    `INSERT INTO wensoul_user_storage_files
+      (user_id, file_name, file_path, file_size, file_type, mime_type, metadata)
+     VALUES (?, ?, ?, ?, 'workflow', 'text/plain', JSON_OBJECT('runId', ?, 'nodeId', ?))`,
+    [userId, fileName, fileName, fileSize, runId, nodeId]
+  );
+  await pool.query(
+    `UPDATE wensoul_user_storage SET used_space = used_space + ?, file_count = file_count + 1 WHERE user_id = ?`,
+    [fileSize, userId]
+  );
+  return { fileId: result.insertId, fileName };
+}
+
+async function getNodeOutputFile(runId, nodeId, userId) {
+  const [rows] = await pool.query(
+    `SELECT file_name, file_path FROM wensoul_user_storage_files
+     WHERE user_id = ? AND JSON_EXTRACT(metadata,'$.runId') = ?
+       AND JSON_EXTRACT(metadata,'$.nodeId') = ? AND status = 1
+     ORDER BY create_time DESC LIMIT 1`,
+    [userId, runId, nodeId]
+  );
+  if (rows.length === 0) {
+    throw new Error('File not found');
+  }
+  const { file_name: fileName, file_path: filePath } = rows[0];
+  return { fileName, filePath: path.join(STORAGE_DIR, filePath) };
+}
+
+module.exports = {
+  getRunById,
+  saveNodeOutput,
+  getNodeOutputFile,
+};


### PR DESCRIPTION
## Summary
- create workflowService for run retrieval and file storage
- expose `/api/workflows` endpoints
- mount workflow routes in server
- keep storage directory tracked

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a0899dc483289e81e3d2e152b29e